### PR TITLE
Default to iPhone 6

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -102,7 +102,7 @@ generateConfig = (name) ->
   log 'Creating Re-Natal config'
   config =
     name:   name
-    device: getUuidForDevice 'iPhone 6s'
+    device: getUuidForDevice 'iPhone 6'
 
   writeConfig config
   config
@@ -327,7 +327,7 @@ init = (projName) ->
 
 launch = ({name, device}) ->
   unless device in getDeviceUuids()
-    log 'Device ID not available, defaulting to iPhone 6s simulator', 'yellow'
+    log 'Device ID not available, defaulting to iPhone 6 simulator', 'yellow'
     {device} = generateConfig name
 
   try


### PR DESCRIPTION
Same change as:

https://github.com/dmotz/natal/issues/38

When initializing a project, the .re-natal config file was not created because it "couldn't find device iPhone 6s".

Thanks