### PR TITLE
Add copy-figwheel-bridge command - close #22

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -633,6 +633,12 @@ cli.command 'use-component <name>'
   .action (name) ->
     useComponent(name)
 
+cli.command 'copy-figwheel-bridge'
+  .description 'copy figwheel-bridge.js into project'
+  .action () ->
+    copyFigwheelBridge(readConfig(false).name)
+    log "Copied figwheel-bridge.js"
+
 cli.on '*', (command) ->
   logErr "unknown command #{command[0]}. See re-natal --help for valid commands"
 


### PR DESCRIPTION
As discussed in #22, this command allow re-natal projects that don't have all the re-natal project assumptions to just upgrade figwheel-bridge.js. This allows our upgrade process to be: `npm i re-natal --save-dev && node_modules/.bin/re-natal copy-figwheel-bridge`. Let me know if there's anything I've missed