### PR TITLE
Updated use-figwheel to replace debug url

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -28,7 +28,7 @@ platformRx      = /\$PLATFORM\$/g
 devHostRx       = /\$DEV_HOST\$/g
 ipAddressRx     = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/i
 figwheelUrlRx   = /ws:\/\/[0-9a-zA-Z\.]*:/g
-appDelegateRx   = /http:\/\/[^:]+/g
+serverRx        = /http:\/\/[^:]+/g
 rnVersion       = '0.23.1'
 rnPackagerPort  = 8081
 process.title   = 're-natal'
@@ -462,7 +462,11 @@ updateFigwheelUrls = (devEnvRoot, androidHost, iosHost) ->
 
 updateIosAppDelegate = (projName, iosHost) ->
   appDelegatePath = "ios/#{projName}/AppDelegate.m"
-  edit appDelegatePath, [[appDelegateRx, "http://#{iosHost}"]]
+  edit appDelegatePath, [[serverRx, "http://#{iosHost}"]]
+  
+updateIosRCTWebSocketExecutor = (iosHost) ->
+  RCTWebSocketExecutorPath = "node_modules/react-native/Libraries/WebSocket/RCTWebSocketExecutor.m"
+  edit RCTWebSocketExecutorPath, [[serverRx, "http://#{iosHost}"]]
 
 generateDevScripts = () ->
   try
@@ -491,6 +495,9 @@ generateDevScripts = () ->
 
     updateIosAppDelegate(projName, iosDevHost)
     log "AppDelegate.m was updated"
+    
+    updateIosRCTWebSocketExecutor(iosDevHost)
+    log "RCTWebSocketExecutor.m was updated"
 
     updateFigwheelUrls(devEnvRoot, androidDevHost, iosDevHost)
     log 'Dev server host for iOS: ' + iosDevHost


### PR DESCRIPTION
If you want to debug on the device you have to replace `localhost`
with your ip in `node_modules/react-native/Libraries/WebSocket/RCTWebSocketExecutor.m`.

Yes it is not a joke, edit the react-native library directly as per: [the docs](https://facebook.github.io/react-native/docs/debugging.html#chrome-developer-tools)

I added this file to where the url is replaced in AppDelegate.m