### PR TITLE
Exclude ds store

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ $ cd ../already-existing
 and run the re-natal command line like so
 
 ```
-node ../re-natal/index.js
+$ node ../re-natal/index.js
 
   Usage: re-natal [options] [command]
 

--- a/README.md
+++ b/README.md
@@ -349,3 +349,49 @@ tools.
     - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 - [Xcode](https://developer.apple.com/xcode) (+ Command Line Tools) `>=6.3` (optional for Android)
     - [OS X](http://www.apple.com/osx) `>=10.10`
+
+
+## Local Development
+
+If you would like to run any of this on your local environment first clone the code to an appropriate place on your machine and install dependencies
+
+```
+$ git clone https://github.com/drapanjanas/re-natal.git
+$ cd re-natal
+$ npm install
+```
+
+To test any changes made to re-natal, cd to an already existing project or a brand new dummy project:
+
+```
+$ cd ../already-existing
+```
+
+and run the re-natal command line like so
+
+```
+node ../re-natal/index.js
+
+  Usage: re-natal [options] [command]
+
+
+  Commands:
+
+    init [options] <name>      create a new ClojureScript React Native project
+    upgrade                    upgrades project files to current installed version of re-natal (the upgrade of re-natal itself is done via npm)
+    xcode                      open Xcode project
+    deps                       install all dependencies for the project
+    use-figwheel               generate index.ios.js and index.android.js for development with figwheel
+    use-android-device <type>  sets up the host for android device type: 'real' - localhost, 'avd' - 10.0.2.2, 'genymotion' - 10.0.3.2
+    use-ios-device <type>      sets up the host for ios device type: 'simulator' - localhost, 'device' - auto detect IP on eth0, IP
+    use-component <name>       configures a custom component to work with figwheel. name is the value you pass to (js/require) function.
+    enable-source-maps         patches RN packager to server *.map files from filesystem, so that chrome can download them.
+    copy-figwheel-bridge       copy figwheel-bridge.js into project
+
+  Options:
+
+    -h, --help     output usage information
+    -V, --version  output the version number
+```
+
+You can then run any of the commands manually.

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -216,14 +216,19 @@ scanImageDir = (dir) ->
   fnames = fs.readdirSync(dir)
     .map (fname) -> "#{dir}/#{fname}"
     .filter (path) -> fs.statSync(path).isFile()
+    .filter (path) -> removeExcludeFiles(path)
     .map (path) -> path.replace /@2x|@3x/i, ''
     .filter (v, idx, slf) -> slf.indexOf(v) == idx
 
   dirs = fs.readdirSync(dir)
     .map (fname) -> "#{dir}/#{fname}"
     .filter (path) -> fs.statSync(path).isDirectory()
-
   fnames.concat scanImages(dirs)
+
+removeExcludeFiles = (file) ->
+    excludedFileNames = [".DS_Store"]
+    res = excludedFileNames.map (ex) -> (file.indexOf ex) == -1
+    true in res
 
 scanImages = (dirs) ->
   imgs = []


### PR DESCRIPTION
If a .DS_Store file is created by OS X in the images directory then re-natal will attempt to
require it like any other image file. This causes an error in the simulator as javascript cannot load
the file. As there isnt any reason why a .DS_Store file should be loaded I've added an automatic exclusion for this file name in any part of the image path.

Additions that could be made:

We could expose the exclude list as a configuration in the .re-natal file so that people could see what is being excluded and add to it if needed.