### PR TITLE
Set goog.DEBUG and only check schema in development

### DIFF
--- a/resources/cljs-reagent/handlers.cljs
+++ b/resources/cljs-reagent/handlers.cljs
@@ -11,11 +11,13 @@
 (defn check-and-throw
   "throw an exception if db doesn't match the schema."
   [a-schema db]
-    (if-let [problems (s/check a-schema db)]
+    (when-let [problems (s/check a-schema db)]
       (throw (js/Error. (str "schema check failed: " problems)))))
 
 (def validate-schema-mw
-  (after (partial check-and-throw schema)))
+  (if goog.DEBUG
+    (after (partial check-and-throw schema))
+    []))
 
 ;; -- Handlers --------------------------------------------------------------
 

--- a/resources/cljs-reagent6/handlers.cljs
+++ b/resources/cljs-reagent6/handlers.cljs
@@ -11,11 +11,13 @@
 (defn check-and-throw
   "throw an exception if db doesn't match the schema."
   [a-schema db]
-    (if-let [problems (s/check a-schema db)]
+    (when-let [problems (s/check a-schema db)]
       (throw (js/Error. (str "schema check failed: " problems)))))
 
 (def validate-schema-mw
-  (after (partial check-and-throw schema)))
+  (if goog.DEBUG
+    (after (partial check-and-throw schema))
+    []))
 
 ;; -- Handlers --------------------------------------------------------------
 

--- a/resources/project.clj
+++ b/resources/project.clj
@@ -35,12 +35,14 @@
                                                                             :output-dir    "target/ios"
                                                                             :static-fns    true
                                                                             :optimize-constants true
-                                                                            :optimizations :simple}}
+                                                                            :optimizations :simple
+                                                                            :closure-defines {"goog.DEBUG" false}}}
                                                    :android {:source-paths ["src" "env/prod"]
                                                              :compiler     {:output-to     "index.android.js"
                                                                             :main          "env.android.main"
                                                                             :output-dir    "target/android"
                                                                             :static-fns    true
                                                                             :optimize-constants true
-                                                                            :optimizations :simple}}}}
+                                                                            :optimizations :simple
+                                                                            :closure-defines {"goog.DEBUG" false}}}}}
                               }})


### PR DESCRIPTION
- `goog.DEBUG` is set to `false` by default in `advanced` optimisation mode. Since we using the `simple` mode, its recommended to set it manually.
- The app should only be checking the schema in development mode and not production mode.