### PR TITLE
Warn the reader that init takes a while.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ re-natal init FutureApp -i [om-next | reagent6 | rum]
 If your app's name is more than a single word, be sure to type it in CamelCase.
 A corresponding hyphenated Clojure namespace will be created.
 
-If all goes well you should see printed out basic instructions how to run in iOS simulator.
+The init process will take a few minutes — coffee break! If all goes well you should see printed out basic instructions how to run in iOS simulator.
 
 ```
 $ cd future-app


### PR DESCRIPTION
The first time I ran `re-natal init` I waited quite a while, staring at "Creating Leiningen project", before deciding that something had gone wrong. After re-checking all my deps, I tried it again and just left it longer (this is Java after all). Many minutes later, it said "Creating React Native skeleton. Relax, this takes a while..." and my only thought was, "It would have been very reassuring to have been warned about the wait... right from the start"