### PR TITLE
lein prod-build does not compile CLJS with dependency on om 1.0.0-alpha35 …

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -65,7 +65,7 @@ interfaceConf   =
       android: ["core.cljs"]
       common:  ["state.cljs"]
       other:   [["support.cljs","re_natal/support.cljs"]]
-    deps:      ['[org.omcljs/om "1.0.0-alpha35" :exclusions [cljsjs/react cljsjs/react-dom]]']
+    deps:      ['[org.omcljs/om "1.0.0-alpha41" :exclusions [cljsjs/react cljsjs/react-dom]]']
     shims:     ["cljsjs.react", "cljsjs.react.dom"]
     sampleCommandNs: '(in-ns \'$PROJECT_NAME_HYPHENATED$.state)'
     sampleCommand: '(swap! app-state assoc :app/msg "Hello Native World!")'


### PR DESCRIPTION
…and corresponding clojurescirpt 1.9.198

I was having issues with 'lein prod-build' when initializing a new project with om-next interface.  The current listed dependencies (using om 1.0.0-alpha35) will fail to build because incompatibility with the Clojurescript version 1.9.198.

The exact error will be:

java.lang.IllegalArgumentException: contains? not supported on type: clojure.lang.PersistentList