### PR TITLE
Update lein-figwheel version

### DIFF
--- a/resources/figwheel-bridge.js
+++ b/resources/figwheel-bridge.js
@@ -220,7 +220,7 @@ function loadApp(platform, devHost, onLoadCb) {
                 // seriously React packager? why.
                 var googreq = goog.require;
 
-                googreq('figwheel.connect');
+                googreq('figwheel.connect.' + platform);
             });
         });
     }

--- a/resources/project.clj
+++ b/resources/project.clj
@@ -7,12 +7,12 @@
                            [org.clojure/clojurescript "1.9.198"]
                            $INTERFACE_DEPS$]
             :plugins [[lein-cljsbuild "1.1.4"]
-                      [lein-figwheel "0.5.0-6"]]
+                      [lein-figwheel "0.5.8"]]
             :clean-targets ["target/" "index.ios.js" "index.android.js"]
             :aliases {"prod-build" ^{:doc "Recompile code with prod profile."}
                                    ["do" "clean"
                                     ["with-profile" "prod" "cljsbuild" "once" ]]}
-            :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.0-6"]
+            :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.8"]
                                             [com.cemerick/piggieback "0.2.1"]]
                              :source-paths ["src" "env/dev"]
                              :cljsbuild    {:builds [{:id           "ios"


### PR DESCRIPTION
Update `lein-figwheel` to latest version 0.5.8. Latest versions of lein-figwheel
generate the "figwheel.connect" including the build id, so I updated
figwheel-bridge to concat the platform id.