### PR TITLE
handle platform-specific image files when running use-figwheel

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -216,6 +216,7 @@ scanImageDir = (dir) ->
     .filter (path) -> fs.statSync(path).isFile()
     .filter (path) -> removeExcludeFiles(path)
     .map (path) -> path.replace /@2x|@3x/i, ''
+    .map (path) -> path.replace new RegExp(".(android|ios)" + fpath.extname(path) + "$", "i"), fpath.extname(path)
     .filter (v, idx, slf) -> slf.indexOf(v) == idx
 
   dirs = fs.readdirSync(dir)


### PR DESCRIPTION
Platform-specific file names for images as described in the React-Native docs at http://facebook.github.io/react-native/releases/0.37/docs/images.html