### PR TITLE
Infer components using a regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.1",
+    "check-dependencies": "^1.0.1",
     "coffee-script": "^1.9.3",
     "commander": "^2.8.1",
     "fs-extra": "^0.26.5",
-    "semver": "^5.0.1",
-    "check-dependencies":"^1.0.1"
+    "klaw-sync": "^2.1.0",
+    "semver": "^5.0.1"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -216,8 +216,9 @@ generateConfig = (interfaceName, projName) ->
 
 writeConfig = (config) ->
   try
-    fs.writeFileSync '.re-natal', JSON.stringify config, null, 2
+    fs.writeFileSync './.re-natal', JSON.stringify config, null, 2
   catch {message}
+    logErr message
     logErr \
       if message.match /EACCES/i
         'Invalid write permissions for creating .re-natal config file'
@@ -225,7 +226,7 @@ writeConfig = (config) ->
         message
 
 verifyConfig = (config) ->
-  if !config.modules? || !config.imageDirs? || !config.interface? || !config.envRoots?
+  if !config.platforms? || !config.modules? || !config.imageDirs? || !config.interface? || !config.envRoots?
     throw new Error 're-natal project needs to be upgraded, please run: re-natal upgrade'
 
   config


### PR DESCRIPTION
changes:
- bug fix: writeConfig needs explicit relative path
- cli command: `infer-components` added, calls inferComponents function
- inferComponents method added: parses all cljs files that (presumably) belong to the user, extract calls to `js/require`, compares them to the current config file (verify its integrity first) and if the `modules` entry is different than the infered requires, overwrites them and lets the user know about the differences.

note: platform specific components are not handled yet. I could separate the inferred components based on their path but that is assuming that the `/ios/` `/android/` convention holds which might cause some troubles.