### PR TITLE
Include watchman in dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ have most installed already. Platform dependencies are listed under their respec
 - [npm](https://www.npmjs.com) `>=1.4`
     - [Node.js](https://nodejs.org) `>=4.0.0`
 - [react-native-cli](https://www.npmjs.com/package/react-native-cli) `>=0.1.7` (install with `npm install -g react-native-cli`)
+- [watchman](https://facebook.github.io/watchman/) `>=4.9.0`
 - [Leiningen](http://leiningen.org) `>=2.5.3`
     - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
       


### PR DESCRIPTION
Watchman no longer appears to be optional with the latest version of React Native. Running `react-native start` without Watchman fails with:

```
Loading dependency graph...2017-09-24 10:49 node[25583] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
```