### PR TITLE
Auto-require: infer components in use-figwheel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,28 @@ And you want to use a component called 'some-library/Component':
 ```clojure
 (def Component (js/require "some-library/Component"))
 ```
-This would work when you do `lein prod-build` and run your app, but will fail when you run with Figwheel.
+This works fine when you do `lein prod-build` and run your app. 
+
 The React Native packager statically scans for all calls to `require` and prepares the required
 code to be available at runtime. But, dynamically loaded (by Figwheel) code bypasses this scan
 and therefore requiring the custom component fails.
 
-To overcome this run `use-component`:
+In re-natal this is solved by adding all dependencies in index.*.js file which is scanned by React Native packager.
+
+#### Using auto-require
+
+To enable auto-require feature you have to run command:
+```
+$ re-natal enable-auto-require
+```
+From now on, command `use-figwheel` will scan for all required modules and generate index.*.js with all required dependencies.
+You will have to re-run `use-figwheel` command every time you use new modules via `(js/require "...")` 
+
+This feature is available since re-natal@0.7.0
+
+#### Manually registering dependencies with use-component command
+
+You can register a single dependency manually by running `use-component` command:
 ```
 $ re-natal use-component some-library/Component
 ```

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -948,12 +948,12 @@ cli.command 'enable-source-maps'
   patchReactNativePackager()
 
 cli.command 'enable-auto-require'
-  .description 'Enables scanning for requires in cljs files and automatically add them in use-figwheel'
+  .description 'enables source scanning for automatic required module resolution in use-figwheel command.'
   .action () ->
     autoRequire(true)
 
 cli.command 'disable-auto-require'
-  .description 'Disables auto-require feature in use-figwheel command'
+  .description 'disables auto-require feature in use-figwheel command'
   .action () ->
     autoRequire(false)
 

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -854,6 +854,15 @@ inferComponents = () ->
   else
     log "no new component was imported, defaulting to #{Array.from(modules)}"
 
+autoRequire = (enabled) ->
+  config = readConfig()
+  config.autoRequire = enabled
+  writeConfig(config)
+  if (enabled)
+    log "Auto-Require feature is enabled in use-figwheel command"
+  else
+    log "Auto-Require feature is disabled in use-figwheel command"
+
 cli._name = 're-natal'
 cli.version pkgJson.version
 
@@ -930,6 +939,16 @@ cli.command 'enable-source-maps'
 .description 'patches RN packager to server *.map files from filesystem, so that chrome can download them.'
 .action () ->
   patchReactNativePackager()
+
+cli.command 'enable-auto-require'
+  .description 'Enables scanning for requires in cljs files and automatically add them in use-figwheel'
+  .action () ->
+    autoRequire(true)
+
+cli.command 'disable-auto-require'
+  .description 'Disables auto-require feature in use-figwheel command'
+  .action () ->
+    autoRequire(false)
 
 cli.command 'copy-figwheel-bridge'
   .description 'copy figwheel-bridge.js into project'

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -212,6 +212,7 @@ generateConfig = (interfaceName, projName) ->
     modules: []
     imageDirs: ["images"]
     platforms: {}
+    autoRequire: true
 
   for platform in platforms
     config.platforms[platform] =


### PR DESCRIPTION
Add new commands to enable/disable auto-require feature in `use-figwheel` command.

When enabled, `use-figwheel` command will find all the required modules by scanning *.cljs files and generate index.*.js with all correct requires for particular platform.

This feature supposed to make commands `use-component` and `infer-comonents` not needed anymore
