### PR TITLE
Support local configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "commander": "^2.8.1",
     "fs-extra": "^0.26.5",
     "klaw-sync": "^2.1.0",
-    "semver": "^5.0.1"
+    "semver": "^5.0.1",
+    "deepmerge": "^1.5.2"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -371,7 +371,8 @@ updateGitIgnore = () ->
 
   indexFiles = platforms.map (platform) -> "index.#{platform}.js"
   fs.appendFileSync(".gitignore", indexFiles.join("\n"))
-  fs.appendFileSync(".gitignore", "\ntarget/\n")
+  fs.appendFileSync(".gitignore", "\ntarget/")
+  fs.appendFileSync(".gitignore", "\n.re-natal.local\n")
 
   fs.appendFileSync(".gitignore", "\n# Figwheel\n#\nfigwheel_server.log")
 

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -878,10 +878,10 @@ inferComponents = () ->
 
   writeConfig(config)
 
-autoRequire = (enabled) ->
-  config = readAndVerifyConfig()
-  config.autoRequire = enabled
-  writeConfig(config)
+autoRequire = (enabled, globally = false) ->
+  configFile = if globally then '.re-natal' else '.re-natal.local'
+  config = merge(readConfig(configFile, false), autoRequire: enabled)
+  writeConfig(config, configFile)
   if (enabled)
     log "Auto-Require feature is enabled in use-figwheel command"
   else
@@ -941,13 +941,13 @@ cli.command 'use-figwheel'
 
 cli.command 'use-android-device <type>'
   .description 'sets up the host for android device type: \'real\' - localhost, \'avd\' - 10.0.2.2, \'genymotion\' - 10.0.3.2, IP'
-  .option '-g --global', 'use global .re-natal config intead of .re-natal.local'
+  .option '-g --global', 'use global .re-natal config instead of .re-natal.local'
   .action (type, cmd) ->
     configureDevHostForAndroidDevice type, cmd.global
 
 cli.command 'use-ios-device <type>'
   .description 'sets up the host for ios device type: \'simulator\' - localhost, \'real\' - auto detect IP on eth0, IP'
-  .option '-g --global', 'use global .re-natal config intead of .re-natal.local'
+  .option '-g --global', 'use global .re-natal config instead of .re-natal.local'
   .action (type, cmd) ->
     configureDevHostForIosDevice type, cmd.global
 
@@ -978,13 +978,15 @@ cli.command 'enable-source-maps'
 
 cli.command 'enable-auto-require'
   .description 'enables source scanning for automatic required module resolution in use-figwheel command.'
-  .action () ->
-    autoRequire(true)
+  .option '-g --global', 'use global .re-natal config instead of .re-natal.local'
+  .action (cmd) ->
+    autoRequire(true, cmd.global)
 
 cli.command 'disable-auto-require'
   .description 'disables auto-require feature in use-figwheel command'
-  .action () ->
-    autoRequire(false)
+  .option '-g --global', 'use global .re-natal config instead of .re-natal.local'
+  .action (cmd) ->
+    autoRequire(false, cmd.global)
 
 cli.command 'copy-figwheel-bridge'
   .description 'copy figwheel-bridge.js into project'

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -680,11 +680,6 @@ updateFigwheelUrls = (devEnvRoot, devHost) ->
     mainDevPath = "#{devEnvRoot}/env/#{platform}/main.cljs"
     edit mainDevPath, [[figwheelUrlRx, "ws://#{devHost[platform]}:"]]
 
-# Current RN version (0.29.2) has no host in AppDelegate.m maybe docs are outdated?
-updateIosAppDelegate = (projName, iosHost) ->
-  appDelegatePath = "ios/#{projName}/AppDelegate.m"
-  edit appDelegatePath, [[appDelegateRx, "http://#{iosHost}"]]
-
 updateIosRCTWebSocketExecutor = (iosHost) ->
   RCTWebSocketExecutorPath = "node_modules/react-native/Libraries/WebSocket/RCTWebSocketExecutor.m"
   edit RCTWebSocketExecutorPath, [[debugHostRx, "host] ?: @\"#{iosHost}\";"]]


### PR DESCRIPTION
- Commands `use-ios-device`, `use-android-device`, `enable-auto-require`, `disable-auto-require` now by default writes into `.re-natal.local` config file.
- Same commands accept `-g` or `--global` option to save configuration in .re-natal file
- Command `use-figwheel` reads configuration from both .re-natal and .re-natal.local files
- fixes #112 