### PR TITLE
fix double initialization of figwheel

### DIFF
--- a/resources/cljs-om-next/main_dev.cljs
+++ b/resources/cljs-om-next/main_dev.cljs
@@ -2,17 +2,17 @@
   (:require [om.next :as om]
             [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
             [$PROJECT_NAME_HYPHENATED$.state :as state]
-            [figwheel.client :as figwheel :include-macros true]))
+            [figwheel.client :as fw]))
 
 (enable-console-print!)
 
 (assert (exists? core/init) "Fatal Error - Your core.cljs file doesn't define an 'init' function!!! - Perhaps there was a compilation failure?")
 (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
 
-(figwheel/watch-and-reload
-  :websocket-url "ws://localhost:3449/figwheel-ws"
-  :heads-up-display false
-  :jsload-callback #(om/add-root! state/reconciler core/AppRoot 1))
+(fw/start {
+           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :heads-up-display false
+           :jsload-callback  #(om/add-root! state/reconciler core/AppRoot 1)})
 
 (core/init)
 

--- a/resources/cljs-reagent/main_dev.cljs
+++ b/resources/cljs-reagent/main_dev.cljs
@@ -1,9 +1,9 @@
- (ns ^:figwheel-no-load env.$PLATFORM$.main
+(ns ^:figwheel-no-load env.$PLATFORM$.main
   (:require [reagent.core :as r]
             [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
-            [figwheel.client :as figwheel :include-macros true]))
+            [figwheel.client :as fw]))
 
- (enable-console-print!)
+(enable-console-print!)
 
 (assert (exists? core/init) "Fatal Error - Your core.cljs file doesn't define an 'init' function!!! - Perhaps there was a compilation failure?")
 (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
@@ -14,9 +14,9 @@
 ;; Do not delete, root-el is used by the figwheel-bridge.js
 (def root-el (r/as-element [reloader]))
 
-(figwheel/watch-and-reload
- :websocket-url "ws://$DEV_HOST$:3449/figwheel-ws"
- :heads-up-display false
- :jsload-callback #(swap! cnt inc))
+(fw/start {
+           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :heads-up-display false
+           :jsload-callback  #(swap! cnt inc)})
 
 (core/init)

--- a/resources/cljs-reagent6/main_dev.cljs
+++ b/resources/cljs-reagent6/main_dev.cljs
@@ -1,10 +1,10 @@
- (ns ^:figwheel-no-load env.$PLATFORM$.main
+(ns ^:figwheel-no-load env.$PLATFORM$.main
   (:require [reagent.core :as r]
             [re-frame.core :refer [clear-subscription-cache!]]
             [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
-            [figwheel.client :as figwheel :include-macros true]))
+            [figwheel.client :as fw]))
 
- (enable-console-print!)
+(enable-console-print!)
 
 (assert (exists? core/init) "Fatal Error - Your core.cljs file doesn't define an 'init' function!!! - Perhaps there was a compilation failure?")
 (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
@@ -16,12 +16,12 @@
 (def root-el (r/as-element [reloader]))
 
 (defn force-reload! []
-  (clear-subscription-cache!)
-  (swap! cnt inc))
+      (clear-subscription-cache!)
+      (swap! cnt inc))
 
-(figwheel/watch-and-reload
- :websocket-url "ws://$DEV_HOST$:3449/figwheel-ws"
- :heads-up-display false
- :jsload-callback force-reload!)
+(fw/start {
+           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :heads-up-display false
+           :jsload-callback  force-reload!})
 
 (core/init)

--- a/resources/cljs-rum/main_dev.cljs
+++ b/resources/cljs-rum/main_dev.cljs
@@ -1,6 +1,6 @@
 (ns ^:figwheel-no-load env.$PLATFORM$.main
   (:require [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
-            [figwheel.client :as figwheel :include-macros true]))
+            [figwheel.client :as fw]))
 
 (assert (exists? core/init) "Fatal Error - Your core.cljs file doesn't define an 'init' function!!! - Perhaps there was a compilation failure?")
 (assert (exists? core/root-component-factory) "Fatal Error - Your core.cljs file doesn't define an 'root-component-factory' function!!! - Perhaps there was a compilation failure?")
@@ -8,11 +8,11 @@
 
 (enable-console-print!)
 
-(figwheel/watch-and-reload
-  :websocket-url "ws://localhost:3449/figwheel-ws"
-  :heads-up-display false
-  ;; TODO make this Rum something
-  :jsload-callback #(#'core/mount-app))
+(fw/start {
+           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :heads-up-display false
+           ;; TODO make this Rum something
+           :jsload-callback  #(#'core/mount-app)})
 
 (core/init)
 

--- a/resources/figwheel-bridge.js
+++ b/resources/figwheel-bridge.js
@@ -190,7 +190,7 @@ function loadApp(platform, devHost, onLoadCb) {
     var fileBasePath = serverBaseUrl((isChrome() ? "localhost" : devHost)) + "/" + config.basePath + platform;
 
     // callback when app is ready to get the reloadable component
-    var mainJs = '/figwheel/connect/build_' + platform + '.js';
+    var mainJs = `/env/${platform}/main.js`;
     evalListeners.waitForFinalEval = function (url) {
         if (url.indexOf(mainJs) > -1) {
 	    assertRootElExists(platform);
@@ -212,7 +212,7 @@ function loadApp(platform, devHost, onLoadCb) {
                 // seriously React packager? why.
                 var googreq = goog.require;
 
-                googreq('figwheel.connect.build_' + platform);
+                googreq(`env.${platform}.main`);
             });
         });
     }


### PR DESCRIPTION
- use only (watch-and-reload ...) way to setup figwheel
- do not explicitly require figwheel.connect.build_${platform} from figwheel-bridge.js
- fixes #143 