### PR TITLE
Move figwheel url configuration into generated namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "check-dependencies": "^1.0.1",
     "coffee-script": "^1.9.3",
     "commander": "^2.8.1",
+    "deepmerge": "^1.5.2",
     "fs-extra": "^0.26.5",
+    "handlebars": "^4.0.10",
     "klaw-sync": "^2.1.0",
-    "semver": "^5.0.1",
-    "deepmerge": "^1.5.2"
+    "semver": "^5.0.1"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/resources/cljs-om-next/main_dev.cljs
+++ b/resources/cljs-om-next/main_dev.cljs
@@ -2,7 +2,8 @@
   (:require [om.next :as om]
             [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
             [$PROJECT_NAME_HYPHENATED$.state :as state]
-            [figwheel.client :as fw]))
+            [figwheel.client :as fw]
+            [env.config :as conf]))
 
 (enable-console-print!)
 
@@ -10,7 +11,7 @@
 (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
 
 (fw/start {
-           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :websocket-url    (:$PLATFORM$ conf/figwheel-urls)
            :heads-up-display false
            :jsload-callback  #(om/add-root! state/reconciler core/AppRoot 1)})
 

--- a/resources/cljs-reagent/main_dev.cljs
+++ b/resources/cljs-reagent/main_dev.cljs
@@ -1,7 +1,8 @@
 (ns ^:figwheel-no-load env.$PLATFORM$.main
   (:require [reagent.core :as r]
             [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
-            [figwheel.client :as fw]))
+            [figwheel.client :as fw]
+            [env.config :as conf]))
 
 (enable-console-print!)
 
@@ -15,7 +16,7 @@
 (def root-el (r/as-element [reloader]))
 
 (fw/start {
-           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :websocket-url    (:$PLATFORM$ conf/figwheel-urls)
            :heads-up-display false
            :jsload-callback  #(swap! cnt inc)})
 

--- a/resources/cljs-reagent6/main_dev.cljs
+++ b/resources/cljs-reagent6/main_dev.cljs
@@ -2,7 +2,8 @@
   (:require [reagent.core :as r]
             [re-frame.core :refer [clear-subscription-cache!]]
             [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
-            [figwheel.client :as fw]))
+            [figwheel.client :as fw]
+            [env.config :as conf]))
 
 (enable-console-print!)
 
@@ -20,7 +21,7 @@
       (swap! cnt inc))
 
 (fw/start {
-           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :websocket-url    (:$PLATFORM$ conf/figwheel-urls)
            :heads-up-display false
            :jsload-callback  force-reload!})
 

--- a/resources/cljs-rum/main_dev.cljs
+++ b/resources/cljs-rum/main_dev.cljs
@@ -1,6 +1,7 @@
 (ns ^:figwheel-no-load env.$PLATFORM$.main
   (:require [$PROJECT_NAME_HYPHENATED$.$PLATFORM$.core :as core]
-            [figwheel.client :as fw]))
+            [figwheel.client :as fw]
+            [env.config :as conf]))
 
 (assert (exists? core/init) "Fatal Error - Your core.cljs file doesn't define an 'init' function!!! - Perhaps there was a compilation failure?")
 (assert (exists? core/root-component-factory) "Fatal Error - Your core.cljs file doesn't define an 'root-component-factory' function!!! - Perhaps there was a compilation failure?")
@@ -9,7 +10,7 @@
 (enable-console-print!)
 
 (fw/start {
-           :websocket-url    "ws://$DEV_HOST$:3449/figwheel-ws"
+           :websocket-url    (:$PLATFORM$ conf/figwheel-urls)
            :heads-up-display false
            ;; TODO make this Rum something
            :jsload-callback  #(#'core/mount-app)})

--- a/resources/config.cljs
+++ b/resources/config.cljs
@@ -1,0 +1,7 @@
+(ns env.config)
+
+(def figwheel-urls {
+                    {{#each platforms}}
+                    :{{@key}} "ws://{{this.host}}:3449/figwheel-ws"
+                    {{/each}}
+                    })


### PR DESCRIPTION
Command `re-natal use-figwheel` will now always regenerate the `env.config` namespace. 
This namespace (which is .gitignored) provides figwheel urls  

fixes #145
fixes #114 