### PR TITLE
Use React Native 0.49

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more ClojureScript React Native resources visit [cljsrn.org](http://cljsrn.o
 Contributions are very welcome.
 
 ## Status
-- Uses [React Native] v0.48.4
+- Uses [React Native] v0.49.3
 - Reusable codebase between iOS and Android
 - Figwheel used for REPL and live coding
   - Works in iOS (real device and simulator)

--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -983,9 +983,9 @@ cli.command 'require-all'
     inferComponents()
 
 cli.command 'enable-source-maps'
-.description 'patches RN packager to server *.map files from filesystem, so that chrome can download them.'
-.action () ->
-  patchReactNativePackager()
+  .description 'patches RN packager to server *.map files from filesystem, so that chrome can download them.'
+  .action () ->
+    patchReactNativePackager()
 
 cli.command 'enable-auto-require'
   .description 'enables source scanning for automatic required module resolution in use-figwheel command.'


### PR DESCRIPTION
React Native CLI now generates project with single entry point `index.js`.
Command `re-natal init` now will change corresponding platform files to support separate entry files.
