### PR TITLE
Fix Rum template

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -83,7 +83,7 @@ interfaceConf   =
     sources:
       common:  []
       other:   [["sablono_compiler.clj","sablono/compiler.clj"],["support.cljs","re_natal/support.cljs"]]
-    deps:      ['[rum "0.10.8" :exclusions [cljsjs/react cljsjs/react-dom sablono]]']
+    deps:      ['[rum "0.11.2" :exclusions [cljsjs/react cljsjs/react-dom sablono]]']
     shims:     ["cljsjs.react", "cljsjs.react.dom", "sablono.core"]
     sampleCommandNs: '(in-ns \'$PROJECT_NAME_HYPHENATED$.ios.core)'
     sampleCommand: '(swap! app-state assoc :greeting "Hello Clojure in iOS and Android with Rum!")'

--- a/resources/cljs-rum/support.cljs
+++ b/resources/cljs-rum/support.cljs
@@ -2,7 +2,7 @@
   "Helpers and adapters to be able to mount/remount Rum components in a React Native application.")
 
 (def React (js/require "react"))
-(def create-class (.-createClass React))
+(def create-class (js/require "create-react-class"))
 (def create-factory (.-createFactory React))
 
 (defonce root-component (atom nil))


### PR DESCRIPTION
- fixes #171
- use recent Rum version 0.11.2
- use create-react-class instead of React.createClass in re-natal.support