### PR TITLE
Updates UWP code generator to use new windows file layout

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -507,7 +507,7 @@ generateWindowsProject = (projName) ->
   exec "node -e \"require('react-native-windows/local-cli/generate-windows')('.', '#{projName}', '#{projName}')\""
   fs.unlinkSync 'App.windows.js'
 
-  appReactPagePath = "windows/#{projName}/MainPage.cs"
+  appReactPagePath = "windows/#{projName}/MainReactNativeHost.cs"
   edit appReactPagePath, [[/public.*JavaScriptMainModuleName(.*\s+){4}return\s+"index";(\s+.*){2}/g, ""]]
 
 generateWpfProject = (projName) ->


### PR DESCRIPTION
The windows team changed the name of the C# class they use to host react native in https://github.com/Microsoft/react-native-windows/commit/395a15695438930d4009ae6c3b34804921f670f2#diff-c94100607ff0edcbee5f94d50acdd06d