### PR TITLE
Fix so that internal re-natal .cljs files are excluded from require scan

### DIFF
--- a/re-natal.coffee
+++ b/re-natal.coffee
@@ -718,7 +718,8 @@ extractRequiresFromSourceFile = (file) ->
 
 buildRequireByPlatformMap = () ->
   onlyUserCljs = (item) -> fpath.extname(item.path) == '.cljs' and
-    item.path.indexOf('/target/') < 0 # ignore target dir
+    item.path.indexOf('/target/') < 0 and # ignore target dir
+    item.path.indexOf('/re-natal/') < 0 # ignore re-natal internal cljs files (can happen if re-natal is installed as a devDependency)
   files = klawSync process.cwd(),
     nodir: true
     filter: onlyUserCljs


### PR DESCRIPTION
Fixes so that re-natal may be installed locally in devDependencies, and executed with the `npx` command.