### PR TITLE
Update piggieback dependency from cemerick/piggieback to cider

### DIFF
--- a/resources/project.clj
+++ b/resources/project.clj
@@ -17,11 +17,11 @@
                                     ["with-profile" "advanced" "cljsbuild" "once"]]}
             :jvm-opts ["-XX:+IgnoreUnrecognizedVMOptions" "--add-modules=java.xml.bind"]
             :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.14"]
-                                            [com.cemerick/piggieback "0.2.1"]]
+                                            [cider/piggieback "0.4.0"]]
                              :source-paths ["src" "env/dev"]
                              :cljsbuild    {:builds [
 #_($DEV_PROFILES$)]}
-                             :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}
+                             :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}
                        :prod {:cljsbuild {:builds [
 #_($PROD_PROFILES$)]}}
                        :advanced {:dependencies [[react-native-externs "0.2.0"]]


### PR DESCRIPTION
Problem Statement:-
Could not start lein repl was getting exception 
ERROR: Unhandled REPL handler exception processing message {:id 2c6a0ee4-fe78-42a2-9123-4554022998a6, :op clone}
 Fix:-
Update piggieback deps according to https://github.com/nrepl/piggieback