### PR TITLE
Use figwheel 0.5.18

### DIFF
--- a/resources/figwheel-bridge.js
+++ b/resources/figwheel-bridge.js
@@ -224,7 +224,13 @@ function loadApp(platform, devHost, onLoadCb) {
             shimBaseGoog(fileBasePath);
             importJs(fileBasePath + '/cljs_deps.js', function () {
                 importJs(fileBasePath + '/goog/deps.js', function () {
-                    importIndexJs(fileBasePath);
+                    // This is needed because of RN packager
+                    // seriously React packager? why.
+                    var googreq = goog.require;	
+                    googreq(`env.${platform}.main`);
+
+                    // Hot reloading Works for figwheel 0.5.14, but not 0.5.18 -- why?
+                    // importIndexJs(fileBasePath);                    
                 });
             });
         });

--- a/resources/project.clj
+++ b/resources/project.clj
@@ -7,7 +7,7 @@
                            [org.clojure/clojurescript "1.10.339"]
                            $INTERFACE_DEPS$]
             :plugins [[lein-cljsbuild "1.1.4"]
-                      [lein-figwheel "0.5.14"]]
+                      [lein-figwheel "0.5.18"]]
             :clean-targets ["target/" #_($PLATFORM_CLEAN$)]
             :aliases {"prod-build" ^{:doc "Recompile code with prod profile."}
                                    ["do" "clean"
@@ -16,7 +16,7 @@
                                    ["do" "clean"
                                     ["with-profile" "advanced" "cljsbuild" "once"]]}
             :jvm-opts ["-XX:+IgnoreUnrecognizedVMOptions" "--add-modules=java.xml.bind"]
-            :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.14"]
+            :profiles {:dev {:dependencies [[figwheel-sidecar "0.5.18"]
                                             [com.cemerick/piggieback "0.2.1"]]
                              :source-paths ["src" "env/dev"]
                              :cljsbuild    {:builds [


### PR DESCRIPTION
Context: I upgraded to figwheel 0.5.18 to solve an issue with the clojurescript repl in cider 0.21:
https://github.com/clojure-emacs/cider/issues/2571

Upon doing so, hot reloading broke, but oddly still worked when using an older version of figwheel-bridge.js prior to the changes in https://github.com/drapanjanas/re-natal/pull/185.  I narrowed down the fix to what you see here in this PR, but I'd like to better understand what the underlying issue is, and perhaps there's a better fix that allows us to continue using `importIndexJs`?

This PR also includes the changes in https://github.com/drapanjanas/re-natal/pull/213.